### PR TITLE
feat: fetch blog-specific venues using search tag filtering

### DIFF
--- a/src/hooks/useFetchVenues.js
+++ b/src/hooks/useFetchVenues.js
@@ -2,35 +2,27 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import { ENDPOINTS } from "../utilities/constants";
 
-const useFetchVenues = (username) => {
+export const useFetchVenues = (tag) => {
   const [venues, setVenues] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
   useEffect(() => {
     const controller = new AbortController();
+
     const fetchVenues = async () => {
-      const token = localStorage.getItem("token");
-      const apiKey = localStorage.getItem("apiKey");
-
-      if (!token || !apiKey) {
-        setError("Missing authentication credentials.");
-        setLoading(false);
-        return;
-      }
-
       try {
         const res = await axios.get(
-          `${ENDPOINTS.profiles}/${username}/venues`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "X-Noroff-API-Key": apiKey,
-            },
-            signal: controller.signal,
-          }
+          `${ENDPOINTS.venues}/search?q=${encodeURIComponent(tag)}`,
+          { signal: controller.signal }
         );
-        setVenues(res.data.data || []);
+
+        const results = res.data.data || [];
+
+        console.log("Filtering by tag (search query):", tag);
+        console.log("Results:", results);
+
+        setVenues(results);
       } catch (err) {
         if (axios.isCancel(err)) {
           console.log("Request canceled:", err.message);
@@ -48,9 +40,7 @@ const useFetchVenues = (username) => {
     return () => {
       controller.abort();
     };
-  }, [username]);
+  }, [tag]);
 
   return { venues, loading, error };
 };
-
-export default useFetchVenues;

--- a/src/paths/Blog/CityLiving/CityLivingVenues.jsx
+++ b/src/paths/Blog/CityLiving/CityLivingVenues.jsx
@@ -1,4 +1,5 @@
-import useFetchVenues from "../../../hooks/useFetchVenues";
+import { useFetchVenues } from "../../../hooks/useFetchVenues";
+
 import VenueCard from "../../../components/VenueCard";
 
 const CityLivingVenues = () => {

--- a/src/paths/Blog/SummerResorts/SummerResortsVenues.jsx
+++ b/src/paths/Blog/SummerResorts/SummerResortsVenues.jsx
@@ -1,4 +1,4 @@
-import useFetchVenues from "../../../hooks/useFetchVenues";
+import { useFetchVenues } from "../../../hooks/useFetchVenues";
 import VenueCard from "../../../components/VenueCard";
 
 const SummerResortsVenues = () => {

--- a/src/paths/Blog/UniqueVenues/UniqueVenues.jsx
+++ b/src/paths/Blog/UniqueVenues/UniqueVenues.jsx
@@ -1,4 +1,4 @@
-import useFetchVenues from "../../../hooks/useFetchVenues";
+import { useFetchVenues } from "../../../hooks/useFetchVenues";
 import VenueCard from "../../../components/VenueCard";
 
 const UniqueVenues = () => {

--- a/src/store/useVenueStore.js
+++ b/src/store/useVenueStore.js
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export const useVenueStore = create((set) => ({
   venues: [],
-  setVenues: (venues) => set({ venues }),
   isLoading: true,
-  setLoading: (isLoading) => set({ isLoading }),
+  setVenues: (venues) => set({ venues }),
+  setIsLoading: (isLoading) => set({ isLoading }),
 }));


### PR DESCRIPTION
- Updated useFetchVenues hook to use the /venues/search endpoint
- Venues are now filtered by a tag added to the venue description (e.g. 'CityLiving')
- Enables public fetching without authentication
- Console logs included to verify filtering during development